### PR TITLE
fix: add log for skipped user

### DIFF
--- a/tools/notify-service-user-sync/script.py
+++ b/tools/notify-service-user-sync/script.py
@@ -74,6 +74,8 @@ def main():
                         add_engagement_contact_role(
                             session, engagement["Id"], contact_id
                         )
+                else:
+                    logging.info("⏩ skipping, no Engagement found")
 
                 sleep(1)
             except Exception as ex:  # pylint: disable=broad-except


### PR DESCRIPTION
# Summary
Add a logging message if a user was skipped because there is no existing Engagement.

# Related
- https://github.com/cds-snc/platform-core-services/issues/388